### PR TITLE
feat:  train model using MNISTDatasetManager 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='src',
+    packages=find_packages(where='src'),
+    package_dir={'': 'src'},
+    version='0.1.0',
+    description='Personal project that attempts to incrementally build a nice modular deep learning framework from scratch for learning pruposes.',
+    author='Charlesaraya',
+    license='MIT',
+)

--- a/src/data/mnist_data.py
+++ b/src/data/mnist_data.py
@@ -44,12 +44,6 @@ class MNISTDatasetManager(object):
         Args:
             filepath (str): Path to the file or directory containing the label raw data.
 
-        Returns:
-            np.ndarray: Array of labels, where each label is an integer (e.g., 0 to 9).
-
-        Raises:
-            ValueError: If the file's magic number does not match the expected value (2049).
-
         File Format:
             The label file format is as follows:
             - Offset 0000: Magic number (4 bytes; 3rd byte indicates data type, 4th byte indicates dimensions).


### PR DESCRIPTION
This PR integrates the MNISTDatasetManager on MLP's test case. Some logic has been removed or moved to this class.

### Key changes:
- added MNISTDatasetManager to train model with predefined batch size
- removed test cases using Iris dataset
- removed mini_batch_data method as MNISTDatasetManager implements iterable behaviour that produces mini-batches
- removed one-shot-encode method (now used in MNISTDatasetManager.)
- added setup.py to enable importing modules within the root directory.
- added a more descriptive docstrings to load_labels and load_images methods