### PR TITLE
feat: add layerable classes (implementing Layer interface)

### DIFF
--- a/src/layers/activations.py
+++ b/src/layers/activations.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from layers.layer import Layer
+
 def sigmoid_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
     """Applies Sigmoid activation function to the input.
 
@@ -16,6 +18,17 @@ def sigmoid_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
     if derivative:
         return Z * (1. - Z)
     return 1. / (1. + np.exp(-Z))
+
+class Sigmoid(Layer):
+    def __init__(self):
+        super(Sigmoid, self).__init__()
+
+    def forward(self, Z: np.ndarray) -> np.ndarray:
+        self.h = 1. / (1. + np.exp(-Z))
+        return self.h
+
+    def backward(self, dloss: np.ndarray) -> np.ndarray:
+        return dloss * (self.h * (1. - self.h))
 
 def tanh_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
     """Applies Tanh activation function to the input.
@@ -35,6 +48,17 @@ def tanh_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
         return 1. - tanh**2
     return tanh
 
+class Tanh(Layer):
+    def __init__(self):
+        super(Tanh, self).__init__()
+
+    def forward(self, Z: np.ndarray) -> np.ndarray:
+        self.h = np.tanh(Z)
+        return self.h
+
+    def backward(self, dloss: np.ndarray) -> np.ndarray:
+        return dloss * (1. - np.tanh(self.h)**2)
+
 def relu_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
     """Applies ReLU activation function to the input.
 
@@ -50,6 +74,17 @@ def relu_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
     if derivative:
         return np.where(Z < 0, 0, 1.)
     return np.maximum(0, Z)
+
+class ReLU(Layer):
+    def __init__(self):
+        super(ReLU, self).__init__()
+
+    def forward(self, Z: np.ndarray) -> np.ndarray:
+        self.h = np.maximum(0, Z)
+        return self.h
+
+    def backward(self, dloss: np.ndarray) -> np.ndarray:
+        return dloss * np.where(self.h < 0, 0, 1.)
 
 def softmax_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
     """Applies Softmax activation function to the input.
@@ -68,6 +103,18 @@ def softmax_activation(Z: np.ndarray, derivative: bool = False) -> np.ndarray:
     exp_x = np.exp(Z - np.max(Z, axis=1, keepdims=True))
     y_hat = exp_x / np.sum(exp_x, axis=1, keepdims=True) # predicted probability for each class
     return y_hat
+
+class SoftMax(Layer):
+    def __init__(self):
+        super(SoftMax, self).__init__()
+
+    def forward(self, Z: np.ndarray) -> np.ndarray:
+        exp_x = np.exp(Z - np.max(Z, axis=1, keepdims=True))
+        y_hat = exp_x / np.sum(exp_x, axis=1, keepdims=True) # predicted probability for each class
+        return y_hat
+
+    def backward(self, dloss: np.ndarray) -> np.ndarray:
+        return dloss # for now, calculation done outside as it's tied with cross-entropy loss
 
 ACTIVATION_FN = {
     'sigmoid': sigmoid_activation,

--- a/src/layers/batchnorm.py
+++ b/src/layers/batchnorm.py
@@ -1,8 +1,10 @@
 import numpy as np
 
+from layers.layer import Layer
+
 EPSILON = 1e-8
 
-class BatchNorm:
+class BatchNorm(Layer):
     """Batch Normalization (BatchNorm) for deep learning models.
     
     BatchNorm normalizes the input data within each mini-batch during training and adjusts the distribution of activations.
@@ -14,6 +16,7 @@ class BatchNorm:
             dim (int): Dimension of the layer.
             momentum (float, optional): Determines how much the current mini-batch contributes to the running averages.
         """
+        super(BatchNorm, self).__init__(dim)
         self.momentum = momentum
 
         self.gamma = np.ones((1, dim))
@@ -57,7 +60,7 @@ class BatchNorm:
 
         return self.out
 
-    def backward(self, dloss) -> np.ndarray:
+    def backward(self, dloss: np.ndarray) -> np.ndarray:
         """Backward pass: computes the gradients with respect to the inputs, gamma, and beta.
 
         Args:

--- a/src/layers/layer.py
+++ b/src/layers/layer.py
@@ -2,7 +2,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 
 class Layer:
-    def __init__(self, input_size: int, output_size: int):
+    def __init__(self, input_size: int = 0, output_size: int = 0):
         self.shape = (input_size, output_size)
 
     @abstractmethod

--- a/src/layers/regularizations.py
+++ b/src/layers/regularizations.py
@@ -1,6 +1,8 @@
 import numpy as np
 
-class Dropout:
+from layers.layer import Layer
+
+class Dropout (Layer):
     """Dropout layer for regularizing neural networks.
 
     Dropout randomly deactivates a fraction of the input units during training to reduce overfitting. 
@@ -12,6 +14,7 @@ class Dropout:
         Args:
             rate (float): The dropout rate (the probability of dropping an neuron. i.e.)
         """
+        super(Dropout, self).__init__()
         if not (0 < rate < 1):
             raise ValueError("Rate must be between 0 and 1.")
         self.rate = rate

--- a/src/model/basemodel.py
+++ b/src/model/basemodel.py
@@ -4,8 +4,10 @@ from tqdm import tqdm, trange
 from data.mnist_data import MNISTDatasetManager
 from layers.layer import Layer
 from layers.denselayer import DenseLayer
+from layers.regularizations import Dropout
+from layers.batchnorm import BatchNorm
 import layers.losses as loss_fn
-from layers.activations import ACTIVATION_FN
+from layers.activations import ACTIVATION_FN, Sigmoid, Tanh, SoftMax, ReLU
 
 class BaseModel:
 
@@ -18,7 +20,7 @@ class BaseModel:
 
     def __str__(self):
         self.name = f'model[{self.layers[0].shape[0]}'
-        self.name += ''.join(f'-{layer.shape[1]}' for layer in self.layers)
+        self.name += ''.join(f'-{layer.shape[1]}' for layer in self.layers if layer.shape[0] != 0)
         self.name += ']'
         return self.name
     
@@ -163,7 +165,7 @@ if __name__ == "__main__":
 
     # Architecture
     input_layer = train_data[0].shape[1]
-    hidden_layer = [64]
+    hidden_layer = [512]
     output_layer = train_data[1].shape[1]
 
     number_epochs = [20]
@@ -173,8 +175,18 @@ if __name__ == "__main__":
 
         # Setup NN
         mlp = BaseModel()
+        
+        """ # Option 1
         mlp.add(DenseLayer(input_layer, 64, activation='tanh'))
-        mlp.add(DenseLayer(64, output_layer, activation='softmax'))
+        mlp.add(DenseLayer(64, output_layer, activation='softmax')) """
+
+        # Option 2
+        mlp.add(DenseLayer(input_layer, 512))
+        mlp.add(BatchNorm(512))
+        mlp.add(Tanh())
+        mlp.add(Dropout(0.3))
+        mlp.add(DenseLayer(512, output_layer))
+        mlp.add(SoftMax())
 
         # Train
         output = mlp.train(mnist, epochs, learning_rate)


### PR DESCRIPTION
In this PR we implement all remaining layers: activation, batchnorm, and dropout layers. This way, we'll be able to configure them into the base model.

### Key changes:
- created classes for all activation functions, adding an internal variable that stores the activation during fwd pass, becoming available later for gradient calculation.
- implemented Layer interface an all activation classes, batchnorm and dropout layers
- added a test case using the new modular configuration.