### PR TITLE
feat: add learning schedulers library

### DIFF
--- a/src/model/basemodel.py
+++ b/src/model/basemodel.py
@@ -1,7 +1,9 @@
 import numpy as np
+from math import ceil
 from tqdm import tqdm, trange
 
 from data.mnist_data import MNISTDatasetManager
+from optimizers.schedulers import Scheduler, WarmUpScheduler, StepDecayScheduler, plot_schedule
 from layers.layer import Layer
 from layers.denselayer import DenseLayer
 from layers.regularizations import Dropout
@@ -50,7 +52,7 @@ class BaseModel:
         for layer in reversed(self.layers):
             grad = layer.backward(grad)
 
-    def train(self, datamanager: MNISTDatasetManager, epochs: int, learning_rate: float) -> dict:
+    def train(self, datamanager: MNISTDatasetManager, scheduler: Scheduler, epochs: int) -> dict:
         """Trains the MLP on the training data.
         
         Performs forward and backward passes at a given learning rate, and over a number of epochs.
@@ -68,13 +70,15 @@ class BaseModel:
             - 'training_losses' (list): Training loss values recorded at each epoch.
         """
         training_accuracies, training_losses, validation_accuracies, validation_losses = [], [], [], []
-        self.learning_rate = learning_rate
 
         with trange(epochs) as t:
             for epoch in t:
                 t.set_description(f"Epoch {epoch}") # Monitor epoch progress in terminal
                 batch_accuracies, batch_losses = [], []
                 for X_batch, y_batch in datamanager:
+
+                    self.learning_rate = scheduler.get_lr()
+
                     # Forward Pass
                     y_hat = self.forward(X_batch)
 
@@ -172,41 +176,47 @@ if __name__ == "__main__":
     hidden_layer = [512]
     output_layer = train_data[1].shape[1]
 
-    number_epochs = [10]
-    learning_rate = 1e-3
+    epochs = 10
+    learning_rate = 9e-2
+    learning_rate_start = 1e-3
 
-    for epochs in number_epochs:
+    # Scheduler
+    steps_per_epoch = ceil(train_data[0].size / batch_size)
+    steps_total = steps_per_epoch * epochs
+    basemodel = StepDecayScheduler(learning_rate, step_size=steps_per_epoch*.15, decay_factor=0.95)
+    scheduler = WarmUpScheduler(basemodel, learning_rate_start, learning_rate, steps_total*0.1)
+    #plot_schedule(scheduler, epochs, steps_per_epoch) # Debug
 
-        # Setup NN
-        mlp = BaseModel()
-        
-        """ # Option 1
-        mlp.add(DenseLayer(input_layer, 64, activation='tanh'))
-        mlp.add(DenseLayer(64, output_layer, activation='softmax')) """
+    # Setup NN
+    mlp = BaseModel()
+    
+    """ # Option 1
+    mlp.add(DenseLayer(input_layer, 64, activation='tanh'))
+    mlp.add(DenseLayer(64, output_layer, activation='softmax')) """
 
-        # Option 2
-        mlp.add(DenseLayer(input_layer, 800))
-        mlp.add(Tanh())
-        mlp.add(Dropout(0.2))
-        mlp.add(DenseLayer(800, output_layer))
-        mlp.add(SoftMax())
+    # Option 2
+    mlp.add(DenseLayer(input_layer, 800))
+    mlp.add(Tanh())
+    mlp.add(Dropout(0.5))
+    mlp.add(DenseLayer(800, output_layer))
+    mlp.add(SoftMax())
 
-        # Train
-        output = mlp.train(mnist, epochs, learning_rate)
+    # Train
+    output = mlp.train(mnist, scheduler, epochs)
 
-        # Inference
-        test_probabilities = mlp.forward(test_data[0])
-        test_predictions = np.argmax(test_probabilities, axis=1)
+    # Inference
+    test_probabilities = mlp.forward(test_data[0])
+    test_predictions = np.argmax(test_probabilities, axis=1)
 
-        # Accuracy
-        test_accuracy = np.mean(test_predictions == test_data[1])
+    # Accuracy
+    test_accuracy = np.mean(test_predictions == test_data[1])
 
-        # Results
-        print(f"\n{mlp.__str__()}, Epochs: {epochs}, Batch size: {batch_size}, Learning rate: {learning_rate} \
-                \n{"─" * 15} Loss {"─" * 20} \
-                \nTraining Loss:\t{output['training_losses'][-1]:.3} \
-                \nValid Loss:\t{output['validation_losses'][-1]:.3} \
-                \n{"─" * 15} Accuracies {"─" * 15} \
-                \nTraining Acc.:\t{output['training_accuracies'][-1]:.3%} \
-                \nValid Acc.:\t{output['validation_accuracies'][-1]:.3%} \
-                \nTest Acc.:\t{test_accuracy:.3%}\n")
+    # Results
+    print(f"\n{mlp.__str__()}, Epochs: {epochs}, Batch size: {batch_size}, Learning rate: {learning_rate} \
+            \n{"─" * 15} Loss {"─" * 20} \
+            \nTraining Loss:\t{output['training_losses'][-1]:.3} \
+            \nValid Loss:\t{output['validation_losses'][-1]:.3} \
+            \n{"─" * 15} Accuracies {"─" * 15} \
+            \nTraining Acc.:\t{output['training_accuracies'][-1]:.3%} \
+            \nValid Acc.:\t{output['validation_accuracies'][-1]:.3%} \
+            \nTest Acc.:\t{test_accuracy:.3%}\n")

--- a/src/optimizers/schedulers.py
+++ b/src/optimizers/schedulers.py
@@ -1,0 +1,169 @@
+from abc import ABC, abstractmethod
+import math
+import matplotlib.pyplot as plt
+
+class Scheduler:
+    """Interface that defines a standardized structure for implementing learning rate scheduling strategies in training workflows."""
+    def __init__(self):
+        self.base_scheduler = None
+        self.learning_rate = 0
+        self.current_step = 0
+
+    def step(self):
+        self.current_step += 1
+
+    @abstractmethod
+    def get_lr(self):
+        """Compute the learning rate for a given step."""
+        pass
+
+class WarmUpScheduler(Scheduler):
+    """The WarmUp Scheduler linearly increases the learning rate during a warm-up period."""
+    def __init__(self, base_scheduler: Scheduler, lr_start: float, lr_max: float, warmup_steps: float):
+        """Initilize the WarmUp Scheduler.
+
+        Args:
+            base_scheduler (Scheduler): The main scheduler to use after warm-up.
+            lr_start (float): Starting learning rate for the warm-up period.
+            lr_max (float): Maximum learning rate to reach at the end of the warm-up period.
+            warmup_steps (int): Number of steps for the warm-up phase. When 0, then no warm up. 
+        """
+        super(WarmUpScheduler, self).__init__()
+        self.base_scheduler: Scheduler = base_scheduler
+        self.lr_start = lr_start
+        self.lr_max = lr_max
+        self.warmup_steps = warmup_steps
+
+    def get_lr(self):
+        if self.current_step < self.warmup_steps:
+            self.learning_rate = self.lr_start + (self.lr_max - self.lr_start) * (self.current_step / self.warmup_steps)
+            return self.learning_rate
+        else:
+            self.learning_rate = self.base_scheduler.get_lr()
+            self.base_scheduler.step()
+            return self.learning_rate
+
+class StepDecayScheduler(Scheduler):
+    """The Step Decay Scheduler reduces the learning rate by a factor after a set number of steps."""
+    def __init__(self, lr_start: float, step_size: int = 1, decay_factor: float = 0.9):
+        """Initilize the Step Decay Scheduler. 
+
+        Args:
+            lr_start (float): Starting learning rate.
+            step_size (int): Number of steps between learning rate adjustments
+            decay_factor (float): Multiplicative factor by which to reduce the learning rate. (e.g., 0.1 for reducing the learning rate by 90%)
+        """
+        super(StepDecayScheduler, self).__init__()
+        self.learning_rate = lr_start
+        self.step_size = step_size
+        self.decay_factor = decay_factor
+    
+    def get_lr(self):
+        """Returns the learning rate at the current step based on step decay.
+
+        Returns:
+            float: Adjusted learning rate after applying step decay.
+        """
+        if self.current_step > 0 and self.current_step % self.step_size == 0:
+            self.learning_rate *= self.decay_factor
+        return self.learning_rate
+
+class ExponentialDecayScheduler(Scheduler):
+    """The Exponential Decay Scheduler smoothly decreases the learning rate exponentially."""
+    def __init__(self, lr_start: float, decay_rate: float = 0.001):
+        """Initilize the Exponential Decay Scheduler.
+
+        Args:
+            lr_start (float): Initial learning rate
+            decay_rate (float): The rate at which the learning rate decays after each step.
+        """
+        super(ExponentialDecayScheduler, self).__init__()
+        self.lr_start = lr_start
+        self.decay_rate = decay_rate
+    
+    def get_lr(self):
+        """Returns the learning rate at the current step based on exponential decay.
+
+        Returns:
+            float: Adjusted learning rate after applying exponential decay.
+        """
+        self.learning_rate = self.lr_start * math.exp(-self.decay_rate * self.current_step)
+        return self.learning_rate
+
+class CosineAnnealingScheduler(Scheduler):
+    """The Cosine Annealing Scheduler decreases the learning rate following a cosine function pattern."""
+    def __init__(self, lr_start: float, total_steps: int, min_lr: float = 0.01):
+        """Initilize the Cosine Annealing Scheduler. 
+
+        Args:
+            lr_start (float): Initial learning rate
+            total_steps (float): Total number of steps for the annealing schedule
+            min_lr (float): Minimum learning rate to reach by the end
+        """
+        super(CosineAnnealingScheduler, self).__init__()
+        self.lr_start = lr_start
+        self.total_steps = total_steps
+        self.min_lr = min_lr
+    
+    def get_lr(self):
+        """Returns the learning rate based on cosine annealing.
+
+        Returns:
+            float: Adjusted learning rate after applying cosine function decay.
+        """
+        self.learning_rate = self.min_lr + 0.5 * (self.lr_start - self.min_lr) * (1 + math.cos(math.pi * self.current_step / self.total_steps))
+        return self.learning_rate
+
+def plot_schedule(scheduler: Scheduler, epochs: int, steps_total: int, filepath: str = None):
+    learning_rates = []
+    for _ in range(epochs):
+        for _ in range(steps_total):
+            learning_rates.append(scheduler.get_lr())
+            scheduler.step()
+
+    # Add markers for the start of each epoch
+    epoch_starts = range(0, epochs*steps_total, steps_total)
+    for start in epoch_starts:
+        plt.axvline(x=start, color='red', linestyle='--', alpha=0.6, label="Epoch Start" if start == epoch_starts[0] else None)
+
+    scheduler_name = type(scheduler.base_scheduler).__name__ if scheduler.base_scheduler else type(scheduler).__name__
+    # Add labels and title
+    plt.plot(range(epochs * steps_total), learning_rates)
+    plt.xlabel("Training Steps")
+    plt.ylabel("Learning Rate")
+    full_scheduler_name = scheduler_name + f' with {type(scheduler).__name__}' if scheduler.base_scheduler else scheduler_name
+    plt.suptitle(f"Learning Rate Schedule", fontsize=12)
+    plt.title(f"{full_scheduler_name}", fontsize=10)
+    plt.grid()
+    # Save or show the plot
+    plt.savefig(f'{filepath}/{scheduler_name}.png') if filepath else plt.show()
+    plt.clf()
+    
+if __name__ == '__main__':
+
+    # Set file paths based on added MNIST Datasets
+    config = {
+        'scheduler_plot_filepath': './plots/schedulers',
+    }
+    
+    lr_start = 1e-4
+    lr_max = 5e-3
+
+    epochs = 20
+    data_length = 60000 * 6
+    batch_size = 128
+    num_batches = math.ceil(data_length / batch_size)
+    total_steps = num_batches * epochs
+    
+    warmpup_ratio = 0.1
+    warmup_steps = total_steps * warmpup_ratio
+
+    base_schedulers = []
+    base_schedulers.append(LinearDecayScheduler(lr_start=lr_max, total_steps=total_steps - warmup_steps))
+    base_schedulers.append(StepDecayScheduler(lr_start=lr_max, step_size=300, decay_factor=0.90))
+    base_schedulers.append(ExponentialDecayScheduler(lr_start=lr_max, decay_rate=0.00025))
+    base_schedulers.append(CosineAnnealingScheduler(lr_start=lr_max, total_steps=total_steps - warmup_steps, min_lr=0.0001))
+    
+    for bs in base_schedulers:
+        scheduler = WarmUpScheduler(bs, lr_start, lr_max, warmup_steps)
+        plot_schedule(scheduler, epochs, num_batches, config['scheduler_plot_filepath'])


### PR DESCRIPTION
In this PR the base model will support adding learning schedulers during training. 

Learning schedulers dynamically adjust the learning rate during training, helping the model converge faster and more reliably. This results in better model performance and efficiency.

### Key changes:
- Added a Scheduler interface.
- Added a WarmUp Scheduler: it linearly increase the learning rate up to the starting eta at the beginning of training. 
- Added a Step Decay Scheduler: it decreases the learning rate by a rate every batch of steps.
- Added an Exponential Decay Scheduler: it decreases the learning rate exponentially according to a decay rate.
- Added a Cosine Annealing decay Scheduler: it decreases the learning rate following a cosine function pattern.