### PR TITLE
Fix multiple issues with the scheduler.

### DIFF
--- a/src/model/basemodel.py
+++ b/src/model/basemodel.py
@@ -187,8 +187,7 @@ if __name__ == "__main__":
     steps_total = steps_per_epoch * epochs
     basemodel = StepDecayScheduler(learning_rate, step_size=ceil(steps_per_epoch*.15), decay_factor=0.90)
     scheduler = WarmUpScheduler(basemodel, learning_rate_start, learning_rate, steps_total*0.1)
-    """ plot_schedule(scheduler, epochs, steps_per_epoch) # Debug
-    scheduler.reset() """
+    #plot_schedule(scheduler, epochs, steps_per_epoch) # Debug
 
     # Setup NN
     mlp = BaseModel()

--- a/src/model/basemodel.py
+++ b/src/model/basemodel.py
@@ -101,6 +101,8 @@ class BaseModel:
                     batch_accuracies.append(accuracy)
                     batch_losses.append(loss)
 
+                    scheduler.step()
+
                 # Monitor epoch metrics
                 epoch_loss = batch_losses[-1]
                 epoch_accuracy = batch_accuracies[-1]
@@ -181,11 +183,12 @@ if __name__ == "__main__":
     learning_rate_start = 1e-3
 
     # Scheduler
-    steps_per_epoch = ceil(train_data[0].size / batch_size)
+    steps_per_epoch = ceil(train_data[0].shape[0] / batch_size)
     steps_total = steps_per_epoch * epochs
-    basemodel = StepDecayScheduler(learning_rate, step_size=steps_per_epoch*.15, decay_factor=0.95)
+    basemodel = StepDecayScheduler(learning_rate, step_size=ceil(steps_per_epoch*.15), decay_factor=0.90)
     scheduler = WarmUpScheduler(basemodel, learning_rate_start, learning_rate, steps_total*0.1)
-    #plot_schedule(scheduler, epochs, steps_per_epoch) # Debug
+    """ plot_schedule(scheduler, epochs, steps_per_epoch) # Debug
+    scheduler.reset() """
 
     # Setup NN
     mlp = BaseModel()

--- a/src/optimizers/schedulers.py
+++ b/src/optimizers/schedulers.py
@@ -124,6 +124,7 @@ def plot_schedule(scheduler: Scheduler, epochs: int, steps_per_epoch: int, filep
         for step in range(steps_per_epoch):
             learning_rates.append(scheduler.get_lr())
             scheduler.step()
+    scheduler.reset()
 
     # Add markers for the start of each epoch
     epoch_starts = range(0, epochs*steps_per_epoch, steps_per_epoch)

--- a/src/optimizers/schedulers.py
+++ b/src/optimizers/schedulers.py
@@ -12,6 +12,10 @@ class Scheduler:
     def step(self):
         self.current_step += 1
 
+    def reset(self):
+        self.learning_rate = 0
+        self.current_step = 0
+
     @abstractmethod
     def get_lr(self):
         """Compute the learning rate for a given step."""
@@ -114,21 +118,21 @@ class CosineAnnealingScheduler(Scheduler):
         self.learning_rate = self.min_lr + 0.5 * (self.lr_start - self.min_lr) * (1 + math.cos(math.pi * self.current_step / self.total_steps))
         return self.learning_rate
 
-def plot_schedule(scheduler: Scheduler, epochs: int, steps_total: int, filepath: str = None):
+def plot_schedule(scheduler: Scheduler, epochs: int, steps_per_epoch: int, filepath: str = None):
     learning_rates = []
-    for _ in range(epochs):
-        for _ in range(steps_total):
+    for epoch in range(epochs):
+        for step in range(steps_per_epoch):
             learning_rates.append(scheduler.get_lr())
             scheduler.step()
 
     # Add markers for the start of each epoch
-    epoch_starts = range(0, epochs*steps_total, steps_total)
+    epoch_starts = range(0, epochs*steps_per_epoch, steps_per_epoch)
     for start in epoch_starts:
         plt.axvline(x=start, color='red', linestyle='--', alpha=0.6, label="Epoch Start" if start == epoch_starts[0] else None)
 
     scheduler_name = type(scheduler.base_scheduler).__name__ if scheduler.base_scheduler else type(scheduler).__name__
     # Add labels and title
-    plt.plot(range(epochs * steps_total), learning_rates)
+    plt.plot(range(epochs * steps_per_epoch), learning_rates)
     plt.xlabel("Training Steps")
     plt.ylabel("Learning Rate")
     full_scheduler_name = scheduler_name + f' with {type(scheduler).__name__}' if scheduler.base_scheduler else scheduler_name


### PR DESCRIPTION
This PR fixes a few issues with the scheduler:
- total number of steps was calculated incorrectly: using the training set size (total samples * inputs layer dim) instead of just the number of total samples.
- the calculated step size passed to the StepDecayScheduler base model was a float, thus the step criteria (modulo step size) was never met.
- added a reset method to the Scheduler to ensure the scheduler can be reused again.
- call reset scheduler after plot_schedule has ran the scheduler over epochs and steps.