### PR TITLE
Feat: Save & Load Model Checkpoints

### DIFF
--- a/src/layers/activations.py
+++ b/src/layers/activations.py
@@ -23,7 +23,7 @@ class Sigmoid(Layer):
     def __init__(self):
         super(Sigmoid, self).__init__()
 
-    def forward(self, Z: np.ndarray) -> np.ndarray:
+    def forward(self, Z: np.ndarray, is_training: bool = True) -> np.ndarray:
         self.h = 1. / (1. + np.exp(-Z))
         return self.h
 
@@ -52,7 +52,7 @@ class Tanh(Layer):
     def __init__(self):
         super(Tanh, self).__init__()
 
-    def forward(self, Z: np.ndarray) -> np.ndarray:
+    def forward(self, Z: np.ndarray, is_training: bool = True) -> np.ndarray:
         self.h = np.tanh(Z)
         return self.h
 
@@ -87,7 +87,7 @@ class ReLU(Layer):
         super(ReLU, self).__init__()
         self.alpha = alpha
 
-    def forward(self, Z: np.ndarray) -> np.ndarray:
+    def forward(self, Z: np.ndarray, is_training: bool = True) -> np.ndarray:
         self.h = np.maximum(self.alpha * Z, Z)
         return self.h
 
@@ -116,7 +116,7 @@ class SoftMax(Layer):
     def __init__(self):
         super(SoftMax, self).__init__()
 
-    def forward(self, Z: np.ndarray) -> np.ndarray:
+    def forward(self, Z: np.ndarray, is_training: bool = True) -> np.ndarray:
         exp_x = np.exp(Z - np.max(Z, axis=1, keepdims=True))
         y_hat = exp_x / np.sum(exp_x, axis=1, keepdims=True) # predicted probability for each class
         return y_hat

--- a/src/layers/denselayer.py
+++ b/src/layers/denselayer.py
@@ -26,7 +26,7 @@ class DenseLayer(Layer):
             case 'he':
                 return np.random.randn(self.shape[0], self.shape[1]) * np.sqrt(2 / self.shape[0])
 
-    def forward(self, input_data: np.ndarray):
+    def forward(self, input_data: np.ndarray, is_training: bool = True):
         """Forward pass"""
         self.input = input_data
         # Linear Transform

--- a/src/layers/layer.py
+++ b/src/layers/layer.py
@@ -6,7 +6,7 @@ class Layer:
         self.shape = (input_size, output_size)
 
     @abstractmethod
-    def forward(self, input: np.ndarray):
+    def forward(self, input: np.ndarray, is_training: bool = True):
         """Forward pass"""
         pass
 


### PR DESCRIPTION
In this PR we've added Saving and Loading support to the model.

### Why is it important
Saving model checkpoints is crucial for resuming training without losing progress in case of interruptions and for reproducibility, allowing consistent evaluation or deployment with the exact model state. It also helps in experiment tracking by preserving models at specific stages of training.

### Key changes
- added method to save a checkpoint at a specific file path and current epoch.
- extended the train method to accept checkpoint configuration to pass the directory where checkpoints should be stored, and the epoch frequency checkpoints should be saved.)
- added method to load model using checkpoint file path.
- added logic to epochs loop to ensure its resumed from checkpoint's current epoch
- added random state to checkpoint to ensure reproducibility after resuming training
- added is training flag to Layer interface signature
- fixed forward pass to pass training flag to ensure proper inference (ie batchnorm and dropout layers)