### PR TITLE
feat: add scheduler factory + YACS config

### DIFF
--- a/src/experiments/config.py
+++ b/src/experiments/config.py
@@ -1,57 +1,83 @@
-config = {
-    'dataset': {
-        'train_images_filepath': './data/MNIST/train-images',
-        'train_labels_filepath': './data/MNIST/train-labels',
-        'test_images_filepath': './data/MNIST/test-images',
-        'test_labels_filepath': './data/MNIST/test-labels',
-        'shuffle_train_set': True,
-        'shuffle_test_set': False,
-        'validation_set_length': 10000,
-        'batch_size': 64,
-        'encoder': 'smoothlabel'
-    },
-    'epochs': 10,
-    'layers': [
-        {
-            'name': 'dense',
-            'input': 784,
-            'output': 1000,
-            'weight_init': 'he'
-        },
-        {
-            'name': 'batchnorm',
-            'dim': 1000
-        },
-        {
-            'name': 'relu'
-        },
-        {
-            'name': 'dropout',
-            'rate': 0.4
-        },
-        {
-            'name': 'dense',
-            'input': 1000,
-            'output': 10,
-            'weight_init': 'xavier'
-        },
-        {
-            'name': 'softmax'
-        }
-    ],
-    'scheduler': {
-        'main': {
-            'name': 'warmup',
-            'learning_rate_start': 1e-3,
-            'learning_rate': 9e-2,
-            'warmup_ratio': 0.1
-        },
-        'base': {
-            'name': 'step',
-            'learning_rate': 9e-2,
-            'decay_factor': 0.9,
-            'step_ratio': 0.15
-        },
-    },
-    'log_filepath': './results/logs/'
-}
+import os
+import yaml
+from yacs.config import CfgNode
+
+# YACS overwrite these settings using YAML configs
+# all YAML variables MUST BE defined here first as this is the master list of ALL attributes.
+
+def load_config(config_file: str):
+    """Loads the experiment configuration from a YAML file."""
+    if not os.path.exists(config_file):
+        raise FileNotFoundError(f"Configuration file not found: {config_file}")
+    with open(config_file, 'r') as f:
+        config = yaml.safe_load(f)
+    return CfgNode(config)
+
+def get_cfg_defaults():
+    """Returns a YACS CfgNode with the default configuration."""
+    _C = CfgNode()
+
+    # Dataset
+    _C.dataset = CfgNode()
+    _C.dataset.batch_size = 64
+    _C.dataset.encoder = "onehot"
+    _C.dataset.shuffle_train_set = True
+    _C.dataset.shuffle_test_set = True
+    _C.dataset.validation_set_length = 10000
+    _C.dataset.train_images_filepath = "./data/MNIST/train-images"
+    _C.dataset.train_labels_filepath = "./data/MNIST/train-labels"
+    _C.dataset.test_images_filepath = "./data/MNIST/test-images"
+    _C.dataset.test_labels_filepath = "./data/MNIST/test-labels"
+
+    _C.epochs = 2
+
+    # Model and Layer Configuration
+    _C.layers = []
+    _C.layers.append(CfgNode())
+    _C.layers[-1].name = "dense"
+    _C.layers[-1].params = CfgNode()
+    _C.layers[-1].params.input_size = 784
+    _C.layers[-1].params.output_size = 1000
+    _C.layers[-1].params.weight_init = "he"
+
+    _C.layers.append(CfgNode())
+    _C.layers[-1].name = "batchnorm"
+    _C.layers[-1].params = CfgNode()
+    _C.layers[-1].params.dim = 1000
+
+    _C.layers.append(CfgNode())
+    _C.layers[-1].name = "relu"
+
+    _C.layers.append(CfgNode())
+    _C.layers[-1].name = "dropout"
+    _C.layers[-1].params = CfgNode()
+    _C.layers[-1].params.rate = 0.4
+
+    _C.layers.append(CfgNode())
+    _C.layers[-1].name = "dense"
+    _C.layers[-1].params = CfgNode()
+    _C.layers[-1].params.input_size = 1000
+    _C.layers[-1].params.output_size = 10
+    _C.layers[-1].params.weight_init = "xavier"
+
+    _C.layers.append(CfgNode())
+    _C.layers[-1].name = "softmax"
+
+    # Scheduler
+    _C.scheduler = CfgNode()
+    _C.scheduler.name = "warmup"
+    _C.scheduler.params = CfgNode()
+    _C.scheduler.params.base_scheduler = CfgNode()
+    _C.scheduler.params.base_scheduler.name = "step"
+    _C.scheduler.params.base_scheduler.params = CfgNode()
+    _C.scheduler.params.base_scheduler.params.lr_start = 9e-2
+    _C.scheduler.params.base_scheduler.params.decay_factor = 0.9
+    _C.scheduler.params.base_scheduler.params.step_size = 200
+    _C.scheduler.params.lr_start = 1e-3
+    _C.scheduler.params.lr_max = 9e-2
+    _C.scheduler.params.warmup_steps = 784
+
+    # Logging
+    _C.log_filepath = "./results/logs/"
+
+    return _C.clone()

--- a/src/optimizers/scheduler_factory.py
+++ b/src/optimizers/scheduler_factory.py
@@ -1,0 +1,27 @@
+from math import ceil
+
+from optimizers.schedulers import *
+
+SCHEDULERS = {
+    'warmup': WarmUpScheduler,
+    'step': StepDecayScheduler,
+    'exponential': ExponentialDecayScheduler,
+    'cosine': CosineAnnealingScheduler
+}
+
+class SchedulerFactory:
+    def __init__(self, dataset_len: int, batch_size: int):
+        self.scheduler_map = SCHEDULERS
+        self.steps_per_epoch = ceil(dataset_len / batch_size)
+
+    def create(self, scheduler_config):
+        scheduler = scheduler_config['name']
+        params = scheduler_config.get('params', {}).copy()
+        if scheduler not in self.scheduler_map:
+            raise ValueError(f'Unknown scheduler type: {scheduler}')
+        if scheduler == 'warmup':
+            base_scheduler = self.create(scheduler_config['params']['base_scheduler'])
+            params['base_scheduler'] = base_scheduler
+            return self.scheduler_map[scheduler](**params)
+        else:
+            return self.scheduler_map[scheduler](**params)


### PR DESCRIPTION
In this PR we implement the factory pattern to improve how the learning scheduler is created and configured when running experiments.

### Key changes
- implemented factory pattern to add flexibility when creating the scheduler.
- refactored logic in ExperimentRunner to use SchedulerFactory
- added YACS to manage experiment configuration, which is easy to work with when building the experiment.