### PR TITLE
feat: stream experiments based on experiment config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ __pycache__/
 # C extensions
 *.so
 
+# YAML extensions
+*.yaml
+
 # Distribution / packaging
 .Python
 build/

--- a/main.py
+++ b/main.py
@@ -1,11 +1,26 @@
+import os
+
 from src.experiments.experiment_runner import ExperimentRunner
 from src.data.mnist_data import MNISTDatasetManager
 from src.model.basemodel import BaseModel
-from src.experiments.config import config
+from src.experiments.config import load_config, get_cfg_defaults
 
 def main():
-    experiment = ExperimentRunner(BaseModel, MNISTDatasetManager, config)
-    experiment.run()
+    # Load default configuration
+    config = get_cfg_defaults()
+
+    for file_name in os.listdir(config.config_dir):
+        if not file_name.endswith(('.yaml')):
+            raise Exception(f"File with wrong extension: {file_name}. Only yaml files are accepted.")
+
+        # Merge default config with experiment config
+        file_path = os.path.join(config.config_dir, file_name)
+        experiment_config = load_config(file_path)
+        config.merge_from_other_cfg(experiment_config)
+
+        # Prep and run experiment
+        experiment = ExperimentRunner(BaseModel, MNISTDatasetManager, config)
+        experiment.run()
 
 if __name__ == "__main__":
     main()

--- a/src/experiments/config.py
+++ b/src/experiments/config.py
@@ -80,4 +80,7 @@ def get_cfg_defaults():
     # Logging
     _C.log_filepath = "./results/logs/"
 
+    # Experiment Config directory
+    _C.config_dir = "./src/experiments/configs/"
+
     return _C.clone()

--- a/src/experiments/experiment_runner.py
+++ b/src/experiments/experiment_runner.py
@@ -17,8 +17,8 @@ ENCODERS = {
 
 class ExperimentRunner:
     def __init__(self, model: BaseModel, datamanager: MNISTDatasetManager, config: dict):
-        self.config = get_cfg_defaults()
-        self.config = self.config.merge_from_other_cfg(config)
+        self.config = config
+
         # Init Data Manager
         self.datamanager: MNISTDatasetManager = datamanager(
             self.config['dataset']['batch_size'],
@@ -96,7 +96,7 @@ class ExperimentRunner:
         #model_name = self._create_model_name()
         model_name = self.model.__str__()
         print(f"\n{model_name}, Epochs: {self.config['epochs']}, Batch size: {self.config['dataset']['batch_size']}, " +
-                f"Learning rate: {self.config['scheduler']['base']['learning_rate']} \
+                f"Learning rate: {self.config['scheduler']['params']['lr_max']} \
                 \n{"─" * 15} Loss {"─" * 20} \
                 \nTraining Loss:\t{train_results['training_losses'][-1]:.3} \
                 \nValid Loss:\t{train_results['validation_losses'][-1]:.3} \
@@ -112,7 +112,7 @@ class ExperimentRunner:
         if not os.path.exists(experiment_filepath):
             os.makedirs(experiment_filepath)
 
-        experiment_params = f"_e{self.config['epochs']}_b{self.config['dataset']['batch_size']}_lr{self.config['scheduler']['base']['learning_rate']:.2}"
+        experiment_params = f"_e{self.config['epochs']}_b{self.config['dataset']['batch_size']}_lr{self.config['scheduler']['params']['lr_max']:.2}"
         experiment_name = 'experiment_' + experiment_params + '.json'
         experiment_filepath = os.path.join(
             experiment_filepath,


### PR DESCRIPTION
In this PR we implement new logic that allows us to stream experiments using different experiment configurations. Configuration will be stored in the experiments > configs directory in yaml format. These experiment configuration will merge with a default configuration defined in config.py using YACS.

### Key changes
- ignore yaml files
- add a loop that goes over each experiment config file and merges it with the default configuration before setting up and running the experiment.
- move out config merging out of experiment runner