### PR TITLE
feat: add emnist support

### DIFF
--- a/src/data/encoders.py
+++ b/src/data/encoders.py
@@ -3,9 +3,9 @@ from abc import ABC, abstractmethod
 
 class Encoder:
     """Interface for encoding functions."""
-    def __init__(self):
-        self.labels = None
-        self.nlabels = 0
+    def __init__(self, nlabels: int, label_offset: int = 0):
+        self.nlabels = nlabels
+        self.label_offset = label_offset
 
     @abstractmethod
     def encode(self, labels: np.ndarray):
@@ -14,8 +14,8 @@ class Encoder:
 
 class OneHotEncoder(Encoder):
     """One-hot encoder class."""
-    def __init__(self):
-        super(OneHotEncoder, self).__init__()
+    def __init__(self, nlabels: int, label_offset: int = 0):
+        super(OneHotEncoder, self).__init__(nlabels, label_offset)
 
     def encode(self, labels: np.ndarray):
         """Encodes each target label class into its one-hot format.
@@ -23,17 +23,17 @@ class OneHotEncoder(Encoder):
         Args:
             labels (ndarray): Array of integers representing the target labels.
         """
-        nlabels = max(labels) + 1
         labels_encoded  = []
+        labels = labels - self.label_offset # ensures labels are indexed at 0 (i.e EMNIST 1:26)
         for label in labels:
-            labels_encoded.append(np.zeros(nlabels))
+            labels_encoded.append(np.zeros(self.nlabels))
             labels_encoded[-1][label] = 1
         return np.asarray(labels_encoded)
 
 class SmoothLabelEncoder(Encoder):
     """Smooth Label Encoder class"""
-    def __init__(self, smoothing_factor: float = 0.1):
-        super(SmoothLabelEncoder, self).__init__()
+    def __init__(self, nlabels: int, label_offset: int = 0, smoothing_factor: float = 0.1):
+        super(SmoothLabelEncoder, self).__init__(nlabels)
         self.smoothing_factor = smoothing_factor
 
     def encode(self, labels: np.ndarray):
@@ -42,10 +42,10 @@ class SmoothLabelEncoder(Encoder):
         Args:
             labels (ndarray): Array of integers representing the target labels.
         """
-        nlabels = max(labels) + 1
         labels_encoded  = []
+        labels = labels - self.label_offset
         for label in labels:
-            encoding = self.smoothing_factor / nlabels * np.ones(nlabels)
+            encoding = self.smoothing_factor / self.nlabels * np.ones(self.nlabels)
             encoding[label] = 1 - self.smoothing_factor
             labels_encoded.append(encoding)
         return np.asarray(labels_encoded)

--- a/src/experiments/config.py
+++ b/src/experiments/config.py
@@ -26,6 +26,8 @@ def get_cfg_defaults():
     _C.dataset.transpose = False
     _C.dataset.validation_set_length = 10000
     _C.dataset.name = "MNIST"
+    _C.dataset.nlabels = 10
+    _C.dataset.label_offset = 0
     _C.dataset.train_images_filepath = "./data/MNIST/train-images"
     _C.dataset.train_labels_filepath = "./data/MNIST/train-labels"
     _C.dataset.test_images_filepath = "./data/MNIST/test-images"

--- a/src/experiments/experiment_runner.py
+++ b/src/experiments/experiment_runner.py
@@ -16,7 +16,10 @@ class ExperimentRunner:
         # Init Data Manager
         self.datamanager: MNISTDatasetManager = datamanager(
             self.config['dataset']['batch_size'],
-            self.config['dataset']['encoder']
+            self.config['dataset']['encoder'],
+            self.config['dataset']['nlabels'],
+            self.config['dataset']['label_offset'],
+            self.config['dataset']['transpose']
         )
         # Load Datasets
         self.datamanager.load_data(
@@ -74,7 +77,7 @@ class ExperimentRunner:
         """Evaluates the model on the test dataset."""
         # Inference
         test_probabilities = model.forward(test_data[0], is_training=False)
-        test_predictions = np.argmax(test_probabilities, axis=1)
+        test_predictions = np.argmax(test_probabilities, axis=1) + self.config['dataset']['label_offset']
         # Calculate Accuracy
         test_accuracy = np.mean(test_predictions == test_data[1])
         return test_accuracy


### PR DESCRIPTION
In this PR we add support to the EMNIST dataset.

### Why it is important
Training a model with EMNIST after benchmarking with MNIST is beneficial because EMNIST offers a more complex and diverse dataset, including uppercase and lowercase letters alongside digits, enabling a more thorough evaluation of the model's generalization and robustness to varied character recognition tasks.

### Key changes
- added encoder configuration to config to account for datasets with different number of label classes and offsets
- refactored logic to Encoders