### PR TITLE
fix: batchnorm paramaters are never updated

### DIFF
--- a/src/layers/batchnorm.py
+++ b/src/layers/batchnorm.py
@@ -95,3 +95,9 @@ class BatchNorm(Layer):
         dloss3 = (1.0 / batch_size) * dmu
         dloss = dloss1 + dloss2 + dloss3 # final partial derivatives, 
         return dloss
+
+    def update(self, learning_rate: float):
+        """Update parameters pass"""
+        self.gamma -= learning_rate * self.dgamma
+        self.beta -= learning_rate * self.dbeta
+        return self.gamma, self.beta

--- a/src/layers/denselayer.py
+++ b/src/layers/denselayer.py
@@ -47,3 +47,9 @@ class DenseLayer(Layer):
         dinput = np.dot(doutput, self.weights.T)
 
         return dinput
+
+    def update(self, learning_rate: float):
+        """Update parameters pass"""
+        self.weights -= learning_rate * self.dweights
+        self.bias -= learning_rate * self.dbias
+        return self.weights, self.bias

--- a/src/layers/layer.py
+++ b/src/layers/layer.py
@@ -14,3 +14,7 @@ class Layer:
     def backward(self, output_gradient: np.ndarray):
         """Backward pass"""
         pass
+
+    def update(self, learning_rate: float):
+        """Update parameters pass"""
+        pass

--- a/src/model/basemodel.py
+++ b/src/model/basemodel.py
@@ -100,11 +100,9 @@ class BaseModel:
                     # Backpropagation Pass: Calculate Gradients, Weights & Bias
                     self.backward(grad)
 
-                    # Gradient Descent: Update Weights and Biases
+                    # Gradient Descent: Update Parameters Pass
                     for layer in self.layers:
-                        if isinstance(layer, DenseLayer):
-                            layer.weights -= self.learning_rate * layer.dweights
-                            layer.bias -= self.learning_rate * layer.dbias
+                        layer.update(self.learning_rate)
 
                     # Monitor batch metrics
                     predictions = np.argmax(y_hat, axis=1)


### PR DESCRIPTION
fix: batchnorm paramaters are never updated

- extended Layer interface with update method responsible for updating learning parameter.
- implement update method on Layer subclasses with learning parameters (DenseLayer, BatchNormLayer, and ConvLayer).
- refactored BaseModel to run the update pass.