### PR TITLE
refactor: compile the loss fn, and add defaults to compile method

### DIFF
--- a/src/experiments/experiment_runner.py
+++ b/src/experiments/experiment_runner.py
@@ -62,8 +62,14 @@ class ExperimentRunner:
 
         # Optimizer
         optimizer_factory = OptimizerFactory()
-        optimizer = optimizer_factory.create(self.config['model']['optimizer'])
-        self.model.compile(optimizer)
+        optimizer = optimizer_factory.create(
+            self.config['model']['optimizer']['name'],
+            self.config['model']['optimizer']['params']
+        )
+        self.model.compile(
+            optimizer = optimizer,
+            loss = self.config['loss_fn'],
+        )
 
     def run(self) -> None:
         """Runs an experiment for a given configuration."""
@@ -72,7 +78,6 @@ class ExperimentRunner:
             self.datamanager,
             self.scheduler,
             self.config['epochs'],
-            self.config['loss_fn'],
             checkpoint = [
                 self.config['checkpoint']['filepath'],
                 self.config['checkpoint']['epoch_freq']

--- a/src/model/model.py
+++ b/src/model/model.py
@@ -7,6 +7,7 @@ import pickle
 from data.mnist_data import MNISTDatasetManager
 from optimizers.schedulers import Scheduler
 from optimizers.optimizer import Optimizer
+from optimizers.optimizer_factory import OptimizerFactory
 from layers.layer import Layer
 from layers.dense import Dense
 from losses.losses import Loss, LOSS_FN
@@ -21,6 +22,10 @@ class Model:
         self.validation_accuracies = []
         self.validation_losses = []
         self.name = name if name is not None else self.__class__.__name__
+
+        # Compile attributes
+        self.is_compiled = False
+        self.loss_fn = None
         self.optimizer = None
 
     def add(self, layer: Layer):
@@ -35,21 +40,36 @@ class Model:
         """
         self.layers.append(layer)
 
-    def compile(self, optimizer: Optimizer = None) -> None:
+    def compile(
+        self,
+        optimizer: str | Optimizer = 'sgd',
+        loss: str | Loss = 'cross-entropy-loss'
+    ) -> None:
         """Configures the model for training.
 
         This method assigns the specified optimizer to the model and initializes 
         any necessary optimization-related parameters for trainable layers.
 
         #### Args:
-            - optimizer (Optimizer): The optimization algorithm to be used to 
-                update the model's parameters.
+            - optimizer (Optimizer): The optimization algorithm to be used to update the model's parameters (default = 'sgd').
+            - `loss_fn` (`str` | `Loss`): The loss function to be used to calculate the predictive error of the model (default = 'cross-entropy-loss').
         """
-        if optimizer is not None:
+        # Optimizer
+        if isinstance(optimizer, Optimizer):
             self.optimizer = optimizer
-            for layer in self.layers:
-                if layer.trainable_params is not None:
-                    self.optimizer.init_params(layer.trainable_params)
+        else:
+            optimizer_factory = OptimizerFactory()
+            self.optimizer = optimizer_factory.create(optimizer)
+        for layer in self.layers:
+            if layer.trainable_params is not None:
+                self.optimizer.init_params(layer.trainable_params)
+        # Loss
+        if isinstance(loss, Loss):
+            self.loss_fn = loss
+        else:
+            self.loss_fn: Loss = LOSS_FN[loss]()
+
+        self.is_compiled = True
         return None
 
     def _add_padding(self, info: str, column_span: int = 20):
@@ -123,15 +143,15 @@ class Model:
                 layer.update(self.learning_rate, computed_gradients)
         return None
 
-    def train(self, datamanager: MNISTDatasetManager, scheduler: Scheduler, epochs: int, loss_fn: str, start_epoch: int = 0, checkpoint: list = None) -> dict:
+    def train(self, datamanager: MNISTDatasetManager, scheduler: Scheduler, epochs: int, start_epoch: int = 0, checkpoint: list = None) -> dict:
         """Trains the MLP on the training data.
 
         Performs forward and backward passes at a given learning rate, and over a number of epochs.
 
         #### Args
             - `datamanager` (`MNISTDatasetManager`): A DataManager class containing the training and validation data, as well as an iterator for mini-batch.
+            - `scheduler` (`Scheduler`): The scheduler that will implement the learning rate update strategy during training.
             - `epochs` (int): The number of times the model will iterate over the entire training dataset.
-            - `loss_fn` (`str`): The loss function to be used to calculate the predictive error of the model.
             - `start_epoch` (`int`): 
             - `checkpoint` (`list`): Checkpoint settings (default = `None`).
 
@@ -145,7 +165,9 @@ class Model:
         self.epochs = epochs - start_epoch
         self.datamanager = datamanager
         self.scheduler = scheduler
-        self.loss_fn: Loss = LOSS_FN[loss_fn]()
+
+        if not self.is_compiled:
+            self.compile() # compile with default settings
 
         with trange(self.epochs) as t:
             for epoch in t:

--- a/src/optimizers/optimizer_factory.py
+++ b/src/optimizers/optimizer_factory.py
@@ -23,7 +23,7 @@ class OptimizerFactory:
         """
         self.map = OPTIMIZERS
 
-    def create(self, config):
+    def create(self, name: str, params: dict = {}):
         """Creates a optimizer based on the provided configuration.
 
         This method parses the configuration dictionary to extract the optimizer type and its parameters. 
@@ -37,9 +37,8 @@ class OptimizerFactory:
         #### Returns
             - `object`: The instance of the specified optimizer class initialized with the provided parameters.
         """
-        name = config['name']
-        params = config.get('params', {}).copy()
-        params['name'] = name
+        self.params = params
+        self.params['name'] = name
 
         if name not in self.map:
             raise ValueError(f'Unknown optimizer: {name}')

--- a/src/optimizers/sgd.py
+++ b/src/optimizers/sgd.py
@@ -8,7 +8,7 @@ class SGD(Optimizer):
     This optimizer updates model parameters using the gradient of the loss function 
     while incorporating momentum to accelerate learning and dampen oscillations.
     """
-    def __init__(self, momentum: float, **kwargs):
+    def __init__(self, momentum: float = 0.0, **kwargs):
         """Initializes the SGD with Momentum optimizer.
 
         #### Args


### PR DESCRIPTION
#### Key changes
- add the loss function during model compilation, and not during training.
- add defaults to compile method, hence use the optimizer factory to instantiate a default when an optimizer isn't compiled on the model
- remove config from optimizer signature; instead split in name and params to decouple from experiment runner and configuration)
- compile the model w/o args (using defaults) at the beginning of training if the model was not compiled in advanced. 
- add default momentum to SGD optimizer so that the optimizer factory creates it with defaults.