### PR TITLE
feat: Add Recurrent Layer

### DIFF
--- a/src/experiments/config.py
+++ b/src/experiments/config.py
@@ -57,6 +57,7 @@ def get_cfg_defaults():
     _C.model.optimizer = CfgNode()
     _C.model.optimizer.name = 'sgd'
     _C.model.optimizer.params = CfgNode(new_allowed=True)
+    _C.model.metrics = 'accuracy'
 
     # Checkpoint configuration
     _C.checkpoint = CfgNode()

--- a/src/experiments/experiment_runner.py
+++ b/src/experiments/experiment_runner.py
@@ -69,6 +69,7 @@ class ExperimentRunner:
         self.model.compile(
             optimizer = optimizer,
             loss = self.config['loss_fn'],
+            metrics = self.config['model']['metrics']
         )
 
     def run(self) -> None:

--- a/src/layers/layer.py
+++ b/src/layers/layer.py
@@ -12,9 +12,9 @@ class Layer:
         if uid is not None:
             self.name = f"{self.name}_{uid}"
 
-        self.trainable_params = None
+        self.trainable_params: list = None
         self.total_params = 0
-        self.gradients = None
+        self.gradients: list = None
 
     def set_trainable_params(self, *params) -> None:
         self.trainable_params = []

--- a/src/layers/recurrent.py
+++ b/src/layers/recurrent.py
@@ -1,6 +1,7 @@
 import numpy as np
 from typing import Literal
 
+import data.mnist_data
 from layers.activations import ACTIVATIONS
 from layers.layer import Layer
 
@@ -28,15 +29,28 @@ class Recurrent(Layer):
         """
         super(Recurrent, self).__init__(shape, **kwargs)
 
-        # Initiliaze weights and bias
-        self.weights = self.init_weight(shape, weight_init)
-        self.prev_weights = self.init_weight((shape[1], shape[1]), weight_init)
-        self.bias = np.zeros((1, self.shape[1]))
+        input_dim, hidden_dim, output_dim = shape
+        # Init weights
+        self.weights_x = self.init_weight((input_dim, hidden_dim), weight_init)
+        self.weights_h = self.init_weight((hidden_dim, hidden_dim), weight_init)
+        self.weights_y = self.init_weight((hidden_dim, output_dim), weight_init)
 
+        # Init biases
+        self.bias_h = np.zeros((1, hidden_dim))
+        self.bias_y = np.zeros((1, output_dim))
+
+        # Init hidden state
         self.hidden_state = None
 
-        self.set_trainable_params(self.weights, self.prev_weights, self.bias)
-        self.dweights, self.prev_weights, self.dbias = self.init_gradients()
+        self.set_trainable_params(
+            self.weights_x,
+            self.weights_h,
+            self.weights_y,
+            self.bias_h,
+            self.bias_y,
+        )
+        # Init gradients
+        self.dweights_x, self.dweights_h, self.dweights_y, self.dbias_h, self.dbias_y = self.init_gradients()
 
         # Set activation function
         self.activation: Layer = ACTIVATIONS[activation]
@@ -77,26 +91,42 @@ class Recurrent(Layer):
         #### Returns
             - `np.ndarray`: The output of the layer after applying the linear transformation.
         """
+        # Shape of inputs: (batch_size, sequence_length, input_dim)
         self.input = input_data
-        # Initial state with shape: (batch_size, num_hiddens)
-        batch_size, sequence_length, input_dim = self.input.shape
-        _, hidden_dim = self.shape
+        if self.input.ndim == 2:
+            batch_size, sequence_length = 1, self.input.shape[0]
+            self.input = self.input.reshape((batch_size, sequence_length, -1))
+        elif self.input.ndim == 3:
+            batch_size, sequence_length, _ = self.input.shape
+
+        # Init hidden state. Shape: (batch_size, num_hiddens)
+        hidden_dim = self.shape[1]
         if self.hidden_state is None:
             self.hidden_state = np.zeros((batch_size, hidden_dim))
 
-        output = []
-        # Shape of inputs: (batch_size, sequence_length, input_dim)
+        outputs = []
+        self.hidden_states = []
         for t_step in range(sequence_length):
-            input_t = self.input[:,t_step,:] # Shape: (batch_size, input_dim)
-            input_t_hat = np.dot(input_t, self.weights) + np.dot(self.hidden_state, self.prev_weights) + self.bias
-            self.hidden_state = self.activation.forward(input_t_hat)
-            output.append(self.hidden_state)
+            # Recurrent layer pass
+            input_t = self.input[:, t_step, :] # Shape: (batch_size, input_dim)
+            input_x = np.dot(input_t, self.weights_x)
+            hidden_x = input_x + np.dot(self.hidden_state, self.weights_h) + self.bias_h
 
-        # Shape: (sequence_length, batch_size, hidden_dim)
-        output = np.stack(output, axis=0)
-        # Shape: (batch_size, sequence_length, hidden_dim)
-        output = np.transpose(output, (1, 0, 2))
-        return output, self.hidden_state
+            # Activation
+            hidden_x = self.activation.forward(hidden_x)
+
+            # Output layer pass
+            output_x = np.dot(hidden_x, self.weights_y) + self.bias_y
+
+            self.hidden_states.append(hidden_x)
+            outputs.append(output_x)
+
+        outputs = np.stack(outputs, axis=0)
+        outputs = np.transpose(outputs, axes=(1, 0, 2))
+        self.hidden_states = np.stack(self.hidden_states, axis=0)
+        self.hidden_states = np.transpose(self.hidden_states, axes=(1, 0, 2))
+
+        return outputs[-1]
 
     def backward(self, output_gradient: np.ndarray) -> np.ndarray:
         """Performs the backward pass through the layer.
@@ -110,18 +140,44 @@ class Recurrent(Layer):
         #### Returns
             - `np.ndarray`: The gradient of the loss w.r.t. the layer's input.
         """
-        if self.activation is not None:
-            output_gradient = self.activation.backward(output_gradient)
+        # Shape of inputs: (batch_size, sequence_length, input_dim)
+        _, sequence_length, _ = self.input.shape
+        if output_gradient.ndim == 2:
+            output_gradient = output_gradient.reshape((1, sequence_length, -1))
+        output_gradient = np.transpose(output_gradient, axes=(1, 0, 2))
+        self.hidden_states = np.transpose(self.hidden_states, axes=(1, 0, 2))
 
-        # Gradients for weights and bias
-        self.dweights = np.dot(self.input.T, output_gradient)
-        self.dbias = np.sum(output_gradient, axis=0, keepdims=True)
-        self.gradients = self.dweights, self.dbias
+        dhidden_next = None
+        for t_step in reversed(range(sequence_length)):
+            doutput = output_gradient[t_step]
 
-        # Gradient w.r.t. the input, to be passed to the previous layer
-        dinput = np.dot(output_gradient, self.weights.T)
+            # Gradient w.r.t weights & biases (output layer)
+            self.dweights_y = np.dot(self.hidden_states[t_step].T, doutput)
+            self.dbias_y = np.sum(doutput, axis=0, keepdims=True)
 
-        return dinput
+            # Gradient w.r.t hidden state
+            self.dhidden: np.ndarray = np.dot(doutput, self.weights_y.T)
+
+            # Pull Gradient from next hidden step
+            if dhidden_next is not None: # When we start backprop
+                self.dhidden += np.dot(dhidden_next, self.weights_h.T)
+
+            # Compute gradient w.r.t hidden state
+            self.dhidden = self.activation.backward(self.dhidden)
+
+            dhidden_next = self.dhidden.copy()
+
+            # Gradients w.r.t. weights & biases (recurrent layer)
+            if t_step > 0:
+                self.dweights_h = np.dot(self.hidden_states[t_step-1].T, self.dhidden)
+                self.dbias_h = np.sum(self.dhidden, axis=0, keepdims=True)
+
+            input = self.input[:,t_step,:]
+            self.dweights_x = np.dot(input.T, self.dhidden)
+
+        self.gradients = self.dweights_x, self.dweights_h, self.dweights_y, self.dbias_h, self.dbias_y
+
+        return None
 
     def update(self, learning_rate: float, gradients: list[np.ndarray]) -> None:
         """Updates the layer's parameters (weights and biases) using the computed gradients.
@@ -136,46 +192,100 @@ class Recurrent(Layer):
         #### Returns
             - `None`: Updates the Layer's internal prameters and returns.
         """
-        dweights, dbias = gradients
-        self.weights -= learning_rate * dweights
-        self.bias -= learning_rate * dbias
-        self.trainable_params = self.weights, self.bias
+        dweights_x, dweights_h, dweights_y, dbias_h, dbias_y = gradients
+
+        self.weights_x -= learning_rate * dweights_x
+        self.weights_h -= learning_rate * dweights_h
+        self.bias_h -= learning_rate * dbias_h
+        self.weights_y -= learning_rate * dweights_y
+        self.bias_y -= learning_rate * dbias_y
+
+        self.trainable_params = self.weights_x, self.weights_h, self.weights_y, self.bias_h, self.bias_h
         return None
 
 if __name__ == "__main__":
-    from layers.dense import Dense
-    from data.encoders import OneHotEncoder
+    from sklearn.preprocessing import StandardScaler
+    import math
+    import pandas as pd
 
-    batch_size = 2
-    sequence_length = 3
-    input_dim = 1
-    vocab_length = 5
-    hidden_dim = 32
+    from model.model import Model
+    from data.mnist_data import MNISTDatasetManager
+    from losses.losses import MeanSquaredError
+    from optimizers.schedulers import WarmUpScheduler, StepDecayScheduler
+    from optimizers.sgd import SGD
 
-    onehot = OneHotEncoder(vocab_length)
-    # Generate a random sequence of `sequence_length` from a vocab of `vocab_length`.
-    batch = []
-    for _ in range(batch_size):
-        input = np.random.choice(range(vocab_length), sequence_length, replace=True)
-        input = onehot.encode(input.T)
-        batch.append(input)
-    batch = np.stack(batch)
+    # Load the dataset
+    df = pd.read_csv('./data/time_series/weather/clean_weather.csv')
+    df = df.ffill()
 
-    rnn = Recurrent(shape=(vocab_length, hidden_dim), weight_init='xavier', activation='tanh', name='rnn_1')
-    dense = Dense(shape=(hidden_dim, vocab_length), weight_init='xavier', name='rnn_out')
+    PREDICTORS = ['tmax', 'tmin', 'rain']
+    TARGET = 'tmax_tomorrow'
 
-    output, hidden = rnn.forward(batch)
-    output = dense.forward(output)
+    scaler = StandardScaler()
+    df[PREDICTORS] = scaler.fit_transform(df[PREDICTORS])
+    df[TARGET] = (df[TARGET] - df[TARGET].mean()) / df[TARGET].std()
 
-    def check_len(a, n):
-        """Check the length of a list."""
-        assert len(a) == n, f'list\'s length {len(a)} != expected length {n}'
+    np.random.seed(0)
+    # Shuffle the dataset
+    df = df.sample(frac=1, random_state=42).reset_index(drop=True)  # frac=1 keeps all rows
+    # Define split ratio
+    train_ratio = 0.8
+    val_ratio = 0.10
+    train_end = int(len(df) * train_ratio)
+    val_end = train_end + int(len(df) * val_ratio)
 
-    def check_shape(a, shape):
-        """Check the shape of a tensor."""
-        assert a.shape == shape, \
-                f'tensor\'s shape {a.shape} != expected shape {shape}'
+    # Split the dataset
+    train_data = df.iloc[:train_end]
+    val_data = df.iloc[train_end:val_end]
+    test_data = df.iloc[val_end:]
 
-    check_len(output, batch_size)
-    check_shape(output[0], (sequence_length, vocab_length))
-    check_shape(rnn.hidden_state, (batch_size, hidden_dim))
+    (x_train, y_train), (x_val, y_val), (x_test, y_test) = [(set[PREDICTORS].to_numpy(), set[TARGET].to_numpy()[:,np.newaxis]) for set in (train_data, val_data, test_data)]
+
+    epochs = 10
+    learning_rate = 1e-2
+    learning_rate_start = 1e-6
+    batch_size = 7
+    steps_per_epoch = math.ceil(x_train.shape[0] / batch_size)
+    steps_total = steps_per_epoch * epochs
+
+    # Setup NN
+    rnn = Model(name="rnn")
+
+    datamanager = MNISTDatasetManager(batch_size=batch_size, nlabels=1)
+    datamanager.train_data = (x_train, y_train)
+    datamanager.validation_data = (x_val, y_val)
+    datamanager.test_data = (x_test, y_test)
+
+    # Build model by adding lñayers sequentially
+    rnn.add(Recurrent((3, 4, 1), weight_init='xavier', activation='tanh'))
+
+    rnn.compile(
+        optimizer = SGD(clipvalue=5),
+        loss = MeanSquaredError(),
+    )
+
+    basemodel = StepDecayScheduler(learning_rate, step_size=steps_per_epoch, decay_factor=0.90)
+    scheduler = WarmUpScheduler(basemodel, learning_rate_start, learning_rate, steps_per_epoch*2)
+    # Train
+    output = rnn.train(
+        datamanager,
+        scheduler,
+        epochs,
+    )
+
+    # Inference
+    test_probabilities = rnn.forward(datamanager.test_data[0], is_training=False)
+    test_predictions = np.argmax(test_probabilities, axis=1)
+
+    # Accuracy
+    test_accuracy = np.mean(test_predictions == datamanager.test_data[1])
+
+    # Results
+    print(f"\n{rnn.__str__()}, Epochs: {epochs}, Batch size: {batch_size}, Learning rate: {learning_rate} \
+            \n{"─" * 15} Loss {"─" * 20} \
+            \nTraining Loss:\t{output['training_losses'][-1]:.3} \
+            \nValid Loss:\t{output['validation_losses'][-1]:.3} \
+            \n{"─" * 15} Accuracies {"─" * 15} \
+            \nTraining Acc.:\t{output['training_accuracies'][-1]:.3%} \
+            \nValid Acc.:\t{output['validation_accuracies'][-1]:.3%} \
+            \nTest Acc.:\t{test_accuracy:.3%}\n")

--- a/src/layers/recurrent.py
+++ b/src/layers/recurrent.py
@@ -1,7 +1,6 @@
 import numpy as np
 from typing import Literal
 
-import data.mnist_data
 from layers.activations import ACTIVATIONS
 from layers.layer import Layer
 

--- a/src/layers/recurrent.py
+++ b/src/layers/recurrent.py
@@ -1,0 +1,155 @@
+import numpy as np
+from typing import Literal
+
+from layers.activations import ACTIVATIONS
+from layers.layer import Layer
+
+class Recurrent(Layer):
+    """Implements a recurrent layer in a neural network.
+    """
+    def __init__(
+        self,
+        shape: tuple,
+        weight_init: str = Literal['random', 'xavier', 'he'],
+        activation = None,
+        **kwargs
+    ):
+        """Initializes the Recurrent layer.
+
+        The layer's weights can be initialized using different strategies to improve convergence and training performance.
+
+        ### Args
+            - `shape` (`tuple`): A tuple defining the structure of the layer, specified as (input_size, output_size).
+            - weight_init (str, optional): Specifies the weight initialization strategy:
+                - `'random'` (default): Initializes weights with small random values.
+                - `'xavier'`: Uses Xavier/Glorot initialization, suitable for tanh/sigmoid.
+                - `'he'`: Uses He initialization, ideal for ReLU/Leaky ReLU activations
+            - activation: The activation function to be applied after the linear transformation (default = None).
+        """
+        super(Recurrent, self).__init__(shape, **kwargs)
+
+        # Initiliaze weights and bias
+        self.weights = self.init_weight(shape, weight_init)
+        self.prev_weights = self.init_weight((shape[1], shape[1]), weight_init)
+        self.bias = np.zeros((1, self.shape[1]))
+
+        self.hidden_state = None
+
+        self.set_trainable_params(self.weights, self.prev_weights, self.bias)
+        self.dweights, self.prev_weights, self.dbias = self.init_gradients()
+
+        # Set activation function
+        self.activation: Layer = ACTIVATIONS[activation]
+
+    def init_weight(self, shape, weight_init):
+        """Initializes the weights of a layer using the specified initialization strategy.
+
+        This method supports several common weight initialization techniques, each tailored 
+        to improve model performance and stability during training.
+
+        #### Args
+            - `shape` (`tuple[int]`): the shape of the weights matrix.
+            - `weight_init` (`str`): The strategy for initializing weights. Options include:
+                - `'random'`: Initializes weights with small random values scaled by 0.01.
+                - `'xavier'`: Uses the Xavier/Glorot uniform initialization, suitable for layers with sigmoid or tanh activations.
+                - `'he'`: Uses He initialization, ideal for layers with ReLU or Leaky ReLU activations.
+        #### Returns
+            - `np.ndarray`: The initialized weights with the same shape as the layer.
+        """
+        match weight_init:
+            case 'random':
+                return np.random.randn(*shape) * 0.01
+            case 'xavier':
+                upper = np.sqrt(1.0 / shape[0])
+                lower = -upper
+                return np.random.uniform(lower, upper, shape)
+            case 'he':
+                return np.random.randn(*shape) * np.sqrt(2 / shape[0])
+
+    def forward(self, input_data: np.ndarray, is_training: bool = True):
+        """Performs a forward pass through the layer.
+
+        #### Args
+            - `input_data` (`np.ndarray`): The input data for the layer, typically a 2D array with shape (batch_size, input_features).
+            - `state` (`np.ndarray`): The hidden state from the previous time step.
+            - `is_training` (`bool`, optional): Indicates whether the forward pass is being performed during training or inference (default = True).
+
+        #### Returns
+            - `np.ndarray`: The output of the layer after applying the linear transformation.
+        """
+        # Initial state with shape: (batch_size, num_hiddens)
+        self.hidden_state = np.zeros((input_data.shape[1], self.shape[1])) if self.hidden_state is None else self.hidden_state
+
+        self.input = input_data
+        output = []
+        for input in self.input:  # Shape of inputs: (num_steps, batch_size, num_inputs)
+            input_hat = np.matmul(input, self.weights) + np.matmul(self.hidden_state, self.prev_weights) + self.bias
+            if self.activation is not None:
+                self.hidden_state = self.activation.forward(input_hat)
+            output.append(self.hidden_state)
+
+        return np.stack(output)
+
+    def backward(self, output_gradient: np.ndarray) -> np.ndarray:
+        """Performs the backward pass through the layer.
+
+        This method computes the gradients of the loss w.r.t. the layer's weights, biases, and input. 
+        It propagates the gradient to the previous layer in the network.
+
+        #### Args
+            - `output_gradient` (`np.ndarray`): The gradient of the loss w.r.t. the next layer's output.
+
+        #### Returns
+            - `np.ndarray`: The gradient of the loss w.r.t. the layer's input.
+        """
+        if self.activation is not None:
+            output_gradient = self.activation.backward(output_gradient)
+
+        # Gradients for weights and bias
+        self.dweights = np.dot(self.input.T, output_gradient)
+        self.dbias = np.sum(output_gradient, axis=0, keepdims=True)
+        self.gradients = self.dweights, self.dbias
+
+        # Gradient w.r.t. the input, to be passed to the previous layer
+        dinput = np.dot(output_gradient, self.weights.T)
+
+        return dinput
+
+    def update(self, learning_rate: float, gradients: list[np.ndarray]) -> None:
+        """Updates the layer's parameters (weights and biases) using the computed gradients.
+
+        This method applies gradient descent to adjust the weights and biases of the layer, 
+        minimizing the loss function during training.
+
+        #### Args
+            - `learning_rate` (`float`): The learning rate used to scale the gradient updates.
+            - `gradients` (`list[np.ndarray]`): The list of computed gradients with which apply gradient descent.
+
+        #### Returns
+            - `None`: Updates the Layer's internal prameters and returns.
+        """
+        dweights, dbias = gradients
+        self.weights -= learning_rate * dweights
+        self.bias -= learning_rate * dbias
+        self.trainable_params = self.weights, self.bias
+        return None
+
+if __name__ == "__main__":
+    batch_size, num_inputs, num_hiddens, num_steps = 2, 16, 32, 100
+    rnn = Recurrent(shape=(num_inputs, num_hiddens), weight_init='xavier', activation='tanh', name='rnn_1')
+
+    X = np.ones((num_steps, batch_size, num_inputs))
+    output = rnn.forward(X)
+
+    def check_len(a, n):
+        """Check the length of a list."""
+        assert len(a) == n, f'list\'s length {len(a)} != expected length {n}'
+
+    def check_shape(a, shape):
+        """Check the shape of a tensor."""
+        assert a.shape == shape, \
+                f'tensor\'s shape {a.shape} != expected shape {shape}'
+
+    check_len(output, num_steps)
+    check_shape(output[0], (batch_size, num_hiddens))
+    check_shape(rnn.hidden_state, (batch_size, num_hiddens))

--- a/src/layers/recurrent.py
+++ b/src/layers/recurrent.py
@@ -77,18 +77,26 @@ class Recurrent(Layer):
         #### Returns
             - `np.ndarray`: The output of the layer after applying the linear transformation.
         """
-        # Initial state with shape: (batch_size, num_hiddens)
-        self.hidden_state = np.zeros((input_data.shape[1], self.shape[1])) if self.hidden_state is None else self.hidden_state
-
         self.input = input_data
+        # Initial state with shape: (batch_size, num_hiddens)
+        batch_size, sequence_length, input_dim = self.input.shape
+        _, hidden_dim = self.shape
+        if self.hidden_state is None:
+            self.hidden_state = np.zeros((batch_size, hidden_dim))
+
         output = []
-        for input in self.input:  # Shape of inputs: (num_steps, batch_size, num_inputs)
-            input_hat = np.matmul(input, self.weights) + np.matmul(self.hidden_state, self.prev_weights) + self.bias
-            if self.activation is not None:
-                self.hidden_state = self.activation.forward(input_hat)
+        # Shape of inputs: (batch_size, sequence_length, input_dim)
+        for t_step in range(sequence_length):
+            input_t = self.input[:,t_step,:] # Shape: (batch_size, input_dim)
+            input_t_hat = np.dot(input_t, self.weights) + np.dot(self.hidden_state, self.prev_weights) + self.bias
+            self.hidden_state = self.activation.forward(input_t_hat)
             output.append(self.hidden_state)
 
-        return np.stack(output)
+        # Shape: (sequence_length, batch_size, hidden_dim)
+        output = np.stack(output, axis=0)
+        # Shape: (batch_size, sequence_length, hidden_dim)
+        output = np.transpose(output, (1, 0, 2))
+        return output
 
     def backward(self, output_gradient: np.ndarray) -> np.ndarray:
         """Performs the backward pass through the layer.
@@ -135,11 +143,29 @@ class Recurrent(Layer):
         return None
 
 if __name__ == "__main__":
-    batch_size, num_inputs, num_hiddens, num_steps = 2, 16, 32, 100
-    rnn = Recurrent(shape=(num_inputs, num_hiddens), weight_init='xavier', activation='tanh', name='rnn_1')
+    from layers.dense import Dense
+    from data.encoders import OneHotEncoder
 
-    X = np.ones((num_steps, batch_size, num_inputs))
-    output = rnn.forward(X)
+    batch_size = 2
+    sequence_length = 3
+    input_dim = 1
+    vocab_length = 5
+    hidden_dim = 32
+
+    onehot = OneHotEncoder(vocab_length)
+    # Generate a random sequence of `sequence_length` from a vocab of `vocab_length`.
+    batch = []
+    for _ in range(batch_size):
+        input = np.random.choice(range(vocab_length), sequence_length, replace=True)
+        input = onehot.encode(input.T)
+        batch.append(input)
+    batch = np.stack(batch)
+
+    rnn = Recurrent(shape=(vocab_length, hidden_dim), weight_init='xavier', activation='tanh', name='rnn_1')
+    dense = Dense(shape=(hidden_dim, vocab_length), weight_init='xavier', name='rnn_out')
+
+    output = rnn.forward(batch)
+    output = dense.forward(output)
 
     def check_len(a, n):
         """Check the length of a list."""

--- a/src/layers/recurrent.py
+++ b/src/layers/recurrent.py
@@ -96,7 +96,7 @@ class Recurrent(Layer):
         output = np.stack(output, axis=0)
         # Shape: (batch_size, sequence_length, hidden_dim)
         output = np.transpose(output, (1, 0, 2))
-        return output
+        return output, self.hidden_state
 
     def backward(self, output_gradient: np.ndarray) -> np.ndarray:
         """Performs the backward pass through the layer.
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     rnn = Recurrent(shape=(vocab_length, hidden_dim), weight_init='xavier', activation='tanh', name='rnn_1')
     dense = Dense(shape=(hidden_dim, vocab_length), weight_init='xavier', name='rnn_out')
 
-    output = rnn.forward(batch)
+    output, hidden = rnn.forward(batch)
     output = dense.forward(output)
 
     def check_len(a, n):
@@ -176,6 +176,6 @@ if __name__ == "__main__":
         assert a.shape == shape, \
                 f'tensor\'s shape {a.shape} != expected shape {shape}'
 
-    check_len(output, num_steps)
-    check_shape(output[0], (batch_size, num_hiddens))
-    check_shape(rnn.hidden_state, (batch_size, num_hiddens))
+    check_len(output, batch_size)
+    check_shape(output[0], (sequence_length, vocab_length))
+    check_shape(rnn.hidden_state, (batch_size, hidden_dim))

--- a/src/losses/losses.py
+++ b/src/losses/losses.py
@@ -73,8 +73,12 @@ class MeanSquaredError(Loss):
         #### Returns
             - `float`: The mean squared error averaged across all samples.
         """
-        error = np.sum((y - y_hat)**2, axis=1) / y.shape[1]
-        error_batch = np.sum(error) / y.shape[0]
+        if y.ndim == 2:
+            self.N, self.C = y.shape
+        elif y.ndim == 3:
+            self.N, _, self.C = y.shape
+        error = np.sum((y - y_hat)**2, axis=1) / self.C
+        error_batch = np.sum(error) / self.N
         return error_batch
 
     def backward(self, y_hat: np.ndarray, y: np.ndarray) -> np.ndarray:
@@ -86,8 +90,7 @@ class MeanSquaredError(Loss):
         #### Returns
             - `np.ndarray`: The gradient w.r.t the loss.
         """
-        N, C = y.shape
-        grad = (2 / (N * C)) * y_hat * ((y_hat  - y)  - np.sum((y_hat  - y) * y_hat, axis=1, keepdims=True))
+        grad = (2 / (self.N * self.C)) * y_hat * ((y_hat  - y)  - np.sum((y_hat  - y) * y_hat, axis=1, keepdims=True))
         return grad
 
 LOSS_FN = {

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -1,0 +1,23 @@
+import numpy as np
+from abc import ABC, abstractmethod
+
+class Metric:
+    def __init__(self, name: str):
+        self.name = name
+    @abstractmethod
+    def compute_metric(self, y_hat, y_target):
+        pass
+
+class Accuracy(Metric):
+    def __init__(self, name: str = 'accuracy'):
+        super(Accuracy, self).__init__(name)
+
+    def compute_metric(self, y_hat, y_target):
+        predictions = np.argmax(y_hat, axis=1)
+        accuracy = np.mean(predictions == np.argmax(y_target, axis=1))
+        return accuracy
+
+METRICS = {
+    'accuracy': Accuracy,
+    None: None
+}

--- a/src/model/model.py
+++ b/src/model/model.py
@@ -11,15 +11,16 @@ from optimizers.optimizer_factory import OptimizerFactory
 from layers.layer import Layer
 from layers.dense import Dense
 from losses.losses import Loss, LOSS_FN
+from metrics.metrics import Metric, METRICS
 
 class Model:
     """Model base class.
     """
     def __init__(self, name: str = None):
         self.layers: list[Layer] = []
-        self.training_accuracies = []
+        self.training_metrics = []
         self.training_losses = []
-        self.validation_accuracies = []
+        self.validation_metrics = []
         self.validation_losses = []
         self.name = name if name is not None else self.__class__.__name__
 
@@ -27,6 +28,7 @@ class Model:
         self.is_compiled = False
         self.loss_fn = None
         self.optimizer = None
+        self.metrics: Metric = None
 
     def add(self, layer: Layer):
         """Adds a layer to the model's architecture
@@ -43,7 +45,8 @@ class Model:
     def compile(
         self,
         optimizer: str | Optimizer = 'sgd',
-        loss: str | Loss = 'cross-entropy-loss'
+        loss: str | Loss = 'cross-entropy-loss',
+        metrics = None,
     ) -> None:
         """Configures the model for training.
 
@@ -69,8 +72,15 @@ class Model:
         else:
             self.loss_fn: Loss = LOSS_FN[loss]()
 
+        # Metrics
+        if metrics is not None:
+            self.metrics = METRICS[metrics]()
+
         self.is_compiled = True
         return None
+
+    def compute_metrics(self, x, y, y_pred):
+        pass
 
     def _add_padding(self, info: str, column_span: int = 20):
         return " " * (column_span - len(str(info)))
@@ -159,7 +169,7 @@ class Model:
             - dict: Dictionary containing the following:
                 - `'weights'` (`list[np.ndarray]`): Final weights of the model.
                 - `'bias'` (`list[np.ndarray]`): Final biases of the model.
-                - `'training_accuracies'` (`list[float]`): Training accuracy values recorded at each epoch.
+                - `'training_metrics'` (`list[float]`): Training metric values recorded at each epoch.
                 - `'training_losses'` (`list[float]`): Training loss values recorded at each epoch.
         """
         self.epochs = epochs - start_epoch
@@ -167,14 +177,14 @@ class Model:
         self.scheduler = scheduler
 
         val_loss = 0
-        val_accuracy = 0
+        val_metric = 0
 
         if not self.is_compiled:
             self.compile() # compile with default settings
 
         with trange(self.epochs) as t:
             for epoch in t:
-                batch_accuracies, batch_losses = [], []
+                batch_metrics, batch_losses = [], []
                 self.current_epoch = start_epoch + epoch + 1 # used to track checkpoint's epoch. Offset required to skip 0 index.
 
                 total_batches = ceil(datamanager.train_data[0].shape[0] / datamanager.batch_size)
@@ -198,31 +208,28 @@ class Model:
                     self.update()
 
                     # Monitor batch metrics
-                    predictions = np.argmax(y_hat, axis=1)
-                    accuracy = np.mean(predictions == np.argmax(y_batch, axis=1))
-                    batch_accuracies.append(accuracy)
+                    batch_metric = self.metrics.compute_metric(y_hat, y_batch)
+                    batch_metrics.append(batch_metric)
                     batch_losses.append(loss)
                     if batch_idx % datamanager.batch_size == 0:
-                        t.set_postfix(tLoss = loss, tAcc = accuracy*100, vLoss = val_loss, vAcc = val_accuracy*100)
+                        t.set_postfix(tLoss = loss, tAcc = batch_metric*100, vLoss = val_loss, vAcc = val_metric*100)
 
                     scheduler.step()
 
                 # Monitor epoch metrics
                 epoch_loss = batch_losses[-1]
-                epoch_accuracy = batch_accuracies[-1]
-                self.training_accuracies.append(epoch_accuracy)
+                epoch_metrics = batch_metrics[-1]
+                self.training_metrics.append(epoch_metrics)
                 self.training_losses.append(epoch_loss)
 
                 # Validation
                 if datamanager.validation_data:
                     # Accuracy
-                    val_probabilities = self.forward(datamanager.validation_data[0], is_training=False)
-                    val_predictions = np.argmax(val_probabilities, axis=1)
-                    val_labels = np.argmax(datamanager.validation_data[1], axis=1)
-                    val_accuracy = np.mean(val_predictions == val_labels)
-                    self.validation_accuracies.append(val_accuracy)
+                    y_hat_val = self.forward(datamanager.validation_data[0], is_training=False)
+                    val_metric = self.metrics.compute_metric(y_hat_val, datamanager.validation_data[1])
+                    self.validation_metrics.append(val_metric)
                     # Loss
-                    val_loss = self.loss_fn.forward(val_probabilities, datamanager.validation_data[1])
+                    val_loss = self.loss_fn.forward(y_hat_val, datamanager.validation_data[1])
                     self.validation_losses.append(val_loss)
 
                 # Checkpoint
@@ -231,17 +238,11 @@ class Model:
 
                 # Monitoring Metrics
                 t.refresh()
-                """ t.set_postfix(
-                    tLoss = epoch_loss,
-                    tAcc = epoch_accuracy*100,
-                    vLoss = val_loss,
-                    vAcc = val_accuracy*100
-                ) """
 
         return {
-            'training_accuracies': self.training_accuracies,
+            'training_metrics': self.training_metrics,
             'training_losses': self.training_losses,
-            'validation_accuracies': self.validation_accuracies,
+            'validation_metrics': self.validation_metrics,
             'validation_losses': self.validation_losses
         }
 
@@ -271,9 +272,9 @@ class Model:
         np.random.set_state(nn_model.random_state)
         self.layers = nn_model.layers
 
-        self.training_accuracies = nn_model.training_accuracies
+        self.training_metrics = nn_model.training_metrics
         self.training_losses = nn_model.training_losses
-        self.validation_accuracies = nn_model.validation_accuracies
+        self.validation_metrics = nn_model.validation_metrics
         self.validation_losses = nn_model.validation_losses
 
         self.scheduler = nn_model.scheduler

--- a/src/optimizers/optimizer.py
+++ b/src/optimizers/optimizer.py
@@ -2,8 +2,19 @@ import numpy as np
 
 class Optimizer:
     """Optimizer base class."""
-    def __init__(self, name:str = None):
+    def __init__(
+        self,
+        clip_gradient_value = None,
+        name: str = None,
+    ):
         self.name = name
+        self.clip_gradient_value = clip_gradient_value
+
+    def clip_gradients(self, gradients):
+        if self.clip_gradient_value and self.clip_gradient_value > 0:
+            return np.clip(gradients, -self.clip_gradient_value, self.clip_gradient_value)
+        else:
+            return gradients
 
     def init_params(self, trainable_params: np.ndarray):
         """Initiliaze internal parameters."""

--- a/src/optimizers/sgd.py
+++ b/src/optimizers/sgd.py
@@ -8,7 +8,12 @@ class SGD(Optimizer):
     This optimizer updates model parameters using the gradient of the loss function 
     while incorporating momentum to accelerate learning and dampen oscillations.
     """
-    def __init__(self, momentum: float = 0.0, **kwargs):
+    def __init__(
+        self,
+        momentum: float = 0.0,
+        clip_gradient_value = None,
+        **kwargs,
+    ):
         """Initializes the SGD with Momentum optimizer.
 
         #### Args
@@ -16,7 +21,10 @@ class SGD(Optimizer):
                 of the previous gradient updates.
             - **kwargs: Additional arguments passed to the parent `Optimizer` class.
         """
-        super(SGD, self).__init__(**kwargs)
+        super(SGD, self).__init__(
+            clip_gradient_value = clip_gradient_value,
+            **kwargs,
+        )
         self.momentum = momentum
         self.model_velocities = []
 
@@ -58,7 +66,9 @@ class SGD(Optimizer):
             raise IndexError(f"Index is out of range. Tried to access the {layer_id} from an array of length {len(self.model_velocities)}.")
         for idx, gradient in enumerate(gradients):
             velocity = self.model_velocities[layer_id][idx]
-            self.model_velocities[layer_id][idx] = self.momentum * velocity + (1 - self.momentum) * gradient
+            gradient = self.momentum * velocity + (1 - self.momentum) * gradient
+            gradient = self.clip_gradients(gradient)
+            self.model_velocities[layer_id][idx] = gradient
         return self.model_velocities[layer_id]
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this PR we've added support for Recurrent layers. On top of that a few more features are added: gradient clipping and the Metric class.

### Key changes
- added new RNN layer, with forward, backward and update passes. 
- added test case using the base model and trained on a weather dataset.
- added gradient clipping to avoid exploding gradients (experienced during testing).
- added new metrics attributed set during model compilation; the goal is to abstract metrics from the model, thus support many different use cases (metrics needs).